### PR TITLE
Unpack tuple arguments to fix syntax error

### DIFF
--- a/dem.py
+++ b/dem.py
@@ -2198,7 +2198,8 @@ class KsFromChiWithSmoothing(BaseSpatialGrid):
         shape = upstream_i.shape
         indexes = area.sort(reverse = False)
         (i_s, j_s) = np.unravel_index(indexes, shape)
-        def set_usdsindexes((i, j)):
+        def set_usdsindexes(ij):
+            i, j = ij
             ds_i, ds_j, good = flow_direction.get_flow_to_cell(i, j)
             if good and not visited[ds_i,ds_j]:
                 visited[i,j] = True
@@ -2259,8 +2260,8 @@ class KsFromChiWithSmoothing(BaseSpatialGrid):
                 delta_e = elevation._griddata[ups_i, ups_j] - elevation._griddata[ds_i, ds_j]
             return ret
         
-        def calc_ks((i,j)):
-                        
+        def calc_ks(ij):
+            i, j = ij  
             points = find_points_at_elevation(i, j)     
             if points is not None:
                 pts = zip(*(points))


### PR DESCRIPTION
Arguments to two helper functions are provided as tuples, which causes a syntax error on import. 

This fixes this problem without affecting subsequent code by taking a single variable and unpacking its entries.

```python
In [1]: import dem                                                                                      
Traceback (most recent call last):

  File "/home/rmsare/.local/lib/python3.5/site-packages/IPython/core/interactiveshell.py", line 3267, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)

  File "<ipython-input-1-719193e80f39>", line 1, in <module>
    import dem

  File "/home/rmsare/tmp/TopoAnalysis/dem.py", line 2201
    def set_usdsindexes((i, j)):
                        ^
SyntaxError: invalid syntax
```

Same error occurs with `calc_ks`.