### PR TITLE
Add methods for computing "valid" template orientations for coastal data

### DIFF
--- a/dem.py
+++ b/dem.py
@@ -1652,7 +1652,7 @@ class ScarpWavelet(BaseSpatialGrid):
             
         gdal_file = None
         return return_object  
-    
+
     def plot_orientations(self, *args, **kwargs):
         
         # pop inputs, create those that are needed:
@@ -1714,7 +1714,22 @@ class ScarpWavelet(BaseSpatialGrid):
 
         plt.title(title)
 
-        plt.show(block = False)    
+        plt.show(block = False)
+
+
+    def template_window(self, window_size, age, orientation):
+        nx = self._georef_info.nx
+        ny = self._georef_info.ny
+        dx = self._georef_info.dx
+
+        from scarplet.WindowedTemplate import Scarp
+        template = Scarp(window_size, orientation, age, nx, ny, dx)
+
+        window = template.get_window_limits()
+        curvature_extent = template.get_mask()
+
+        return window * curvature_extent
+
                   
 class LocalRelief(BaseSpatialGrid):
     

--- a/dem.py
+++ b/dem.py
@@ -1653,7 +1653,10 @@ class ScarpWavelet(BaseSpatialGrid):
         return_object._SNR = get_band(gdal_dataset, 4)    
             
         gdal_file = None
-        return return_object  
+        return return_object
+
+    def load_elevation(self, filename):
+        self.elevation = Elevation.load(filename)
 
     def plot_orientations(self, *args, **kwargs):
         
@@ -1718,7 +1721,6 @@ class ScarpWavelet(BaseSpatialGrid):
 
         plt.show(block = False)
 
-
     def template_window(self, window_size, age, orientation, use_pixels=False):
         nx = self._georef_info.nx
         ny = self._georef_info.ny
@@ -1733,7 +1735,6 @@ class ScarpWavelet(BaseSpatialGrid):
 
         return window
 
-                  
 class LocalRelief(BaseSpatialGrid):
     
     required_inputs_and_actions = ((('nx', 'ny', 'projection', 'geo_transform',),'_create'),

--- a/dem.py
+++ b/dem.py
@@ -1735,11 +1735,6 @@ class ScarpWavelet(BaseSpatialGrid):
         min[np.isinf(min)] = np.nan
         return max, min
 
-    def valid_data(self):
-        if self.elevation is None:
-            raise AttributeError('No elevation data! Use load_elevation')
-        return self.elevation._griddata >= 0
-
     def template_window(self, window_size, age, orientation, use_pixels=False):
         nx = self._georef_info.nx
         ny = self._georef_info.ny
@@ -1753,6 +1748,11 @@ class ScarpWavelet(BaseSpatialGrid):
         window = template.get_mask()
 
         return window
+
+    def valid_data(self):
+        if self.elevation is None:
+            raise AttributeError('No elevation data! Use load_elevation')
+        return self.elevation._griddata >= 0
 
 class LocalRelief(BaseSpatialGrid):
     

--- a/dem.py
+++ b/dem.py
@@ -1770,6 +1770,7 @@ class ScarpWavelet(BaseSpatialGrid):
             raise AttributeError('No elevation data! Use load_elevation first')
         valid = np.ones_like(self.elevation._griddata)
         valid[np.isnan(self.elevation._griddata)] = np.nan
+        valid[self.elevation._griddata <= 0] = np.nan
         return valid
 
 class LocalRelief(BaseSpatialGrid):

--- a/dem.py
+++ b/dem.py
@@ -1717,18 +1717,19 @@ class ScarpWavelet(BaseSpatialGrid):
         plt.show(block = False)
 
 
-    def template_window(self, window_size, age, orientation):
+    def template_window(self, window_size, age, orientation, use_pixels=False):
         nx = self._georef_info.nx
         ny = self._georef_info.ny
-        dx = self._georef_info.dx
+        if use_pixels:
+            dx = 1
+        else:
+            dx = self._georef_info.dx
 
         from scarplet.WindowedTemplate import Scarp
-        template = Scarp(window_size, orientation, age, nx, ny, dx)
+        template = Scarp(window_size, age, orientation, nx, ny, dx)
+        window = template.get_mask()
 
-        window = template.get_window_limits()
-        curvature_extent = template.get_mask()
-
-        return window * curvature_extent
+        return window
 
                   
 class LocalRelief(BaseSpatialGrid):

--- a/dem.py
+++ b/dem.py
@@ -1721,6 +1721,11 @@ class ScarpWavelet(BaseSpatialGrid):
 
         plt.show(block = False)
 
+    def valid_data(self):
+        if self.elevation is None:
+            raise AttributeError('No elevation data! Use load_elevation')
+        return self.elevation._griddata >= 0
+
     def template_window(self, window_size, age, orientation, use_pixels=False):
         nx = self._georef_info.nx
         ny = self._georef_info.ny

--- a/dem.py
+++ b/dem.py
@@ -1721,10 +1721,15 @@ class ScarpWavelet(BaseSpatialGrid):
 
         plt.show(block = False)
 
-    def calculate_valid_orientations(self, window_size, age, num=46):
+    def calculate_valid_orientations(self,
+                                     window_size,
+                                     age,
+                                     num=46, 
+                                     discard_max_min=True):
         data = self.valid_data()
         max = -np.inf * np.ones_like(data)
         min = np.inf * np.ones_like(data)
+
         orientations = np.linspace(-np.pi / 2, np.pi / 2, num=num)
         for orientation in orientations:
             this = self._convolve_mask(data, window_size, age, orientation)
@@ -1735,6 +1740,21 @@ class ScarpWavelet(BaseSpatialGrid):
 
         max[np.isinf(max)] = np.nan
         min[np.isinf(min)] = np.nan
+        max[np.isnan(data)] = np.nan
+        min[np.isnan(data)] = np.nan
+
+        max[0:window_size, :] = np.nan
+        max[-window_size:, :] = np.nan
+        max[:, 0:window_size] = np.nan
+        max[:, -window_size:] = np.nan
+        min[0:window_size, :] = np.nan
+        min[-window_size:, :] = np.nan
+        min[:, 0:window_size] = np.nan
+        min[:, -window_size:] = np.nan
+
+        if discard_max_min:
+            max[max == orientations.max()] = np.nan
+            min[min == orientations.min()] = np.nan
 
         return max, min
 

--- a/dem.py
+++ b/dem.py
@@ -1732,9 +1732,9 @@ class ScarpWavelet(BaseSpatialGrid):
 
         orientations = np.linspace(-np.pi / 2, np.pi / 2, num=num)
         for orientation in orientations:
-            # XXX: This uses -orientation to conform to N-E coordinates
-            # i.e. N = 0, E = +90, W = -90
-            this = self._convolve_mask(data, window_size, age, -orientation)
+            # XXX: This uses orientation to conform to N-E coordinates
+            # i.e. N = 0, E = -90, W = +90
+            this = self._convolve_mask(data, window_size, age, orientation)
             mask = (this != this.max()) * (max < orientation)
             max[mask] = orientation
             mask = (this != this.max()) * (min > orientation)

--- a/dem.py
+++ b/dem.py
@@ -1732,7 +1732,9 @@ class ScarpWavelet(BaseSpatialGrid):
 
         orientations = np.linspace(-np.pi / 2, np.pi / 2, num=num)
         for orientation in orientations:
-            this = self._convolve_mask(data, window_size, age, orientation)
+            # XXX: This uses -orientation to conform to N-E coordinates
+            # i.e. N = 0, E = +90, W = -90
+            this = self._convolve_mask(data, window_size, age, -orientation)
             mask = (this != this.max()) * (max < orientation)
             max[mask] = orientation
             mask = (this != this.max()) * (min > orientation)

--- a/dem.py
+++ b/dem.py
@@ -1721,6 +1721,20 @@ class ScarpWavelet(BaseSpatialGrid):
 
         plt.show(block = False)
 
+    def calculate_valid_orientations(self, window_size, age):
+        max = -np.inf * np.ones_like(data)
+        min = np.inf * np.ones_like(data)
+        orientations = np.linspace(-np.pi / 2, np.pi / 2, num=181)
+        for orientation in orientations:
+            this = convolve_mask(data, window_size, age, orientation)
+            mask = (this != this.max()) * (max < orientation)
+            max[mask] = orientation
+            mask = (this != this.max()) * (min > orientation)
+            min[mask] = orientation
+        max[np.isinf(max)] = np.nan
+        min[np.isinf(min)] = np.nan
+        return max, min
+
     def valid_data(self):
         if self.elevation is None:
             raise AttributeError('No elevation data! Use load_elevation')

--- a/dem.py
+++ b/dem.py
@@ -1721,16 +1721,17 @@ class ScarpWavelet(BaseSpatialGrid):
 
         plt.show(block = False)
 
-    def calculate_valid_orientations(self, window_size, age):
+    def calculate_valid_orientations(self, window_size, age, num=46):
         max = -np.inf * np.ones_like(data)
         min = np.inf * np.ones_like(data)
-        orientations = np.linspace(-np.pi / 2, np.pi / 2, num=181)
+        orientations = np.linspace(-np.pi / 2, np.pi / 2, num=num)
         for orientation in orientations:
             this = convolve_mask(data, window_size, age, orientation)
             mask = (this != this.max()) * (max < orientation)
             max[mask] = orientation
             mask = (this != this.max()) * (min > orientation)
             min[mask] = orientation
+
         max[np.isinf(max)] = np.nan
         min[np.isinf(min)] = np.nan
         return max, min


### PR DESCRIPTION
Implements methods using scarp template to

- Load elevation data and coastline footprint
- Count valid (positive, above sea level) pixels in template window over dataset area
- Find range of valid template orientations for each pixel

# Example:

## Maximum orientations, NorCal coastline
![norcal_max](https://user-images.githubusercontent.com/3606852/53136397-b521b480-3533-11e9-94ef-9e0901c59344.png)

## Minimum orientations, NorCal coastline
![norcal_min](https://user-images.githubusercontent.com/3606852/53136411-c965b180-3533-11e9-97da-7143a3039681.png)

## Histogram
![norcal_hist](https://user-images.githubusercontent.com/3606852/53136420-d387b000-3533-11e9-9022-eee873dd86d6.png)
